### PR TITLE
hw: spi_gpio: remove MOSI pin

### DIFF
--- a/hw/arm/aspeed.c
+++ b/hw/arm/aspeed.c
@@ -181,7 +181,6 @@ struct AspeedMachineState {
 /* ASPEED GPIO propname values */
 #define AST_GPIO_IRQ_X0_NUM 185
 #define AST_GPIO_IRQ_X3_NUM 188
-#define AST_GPIO_IRQ_X4_NUM 189
 
 /*
  * The max ram region is for firmwares that scan the address space
@@ -404,8 +403,6 @@ static void aspeed_machine_init(MachineState *machine)
                                 qdev_get_gpio_in_named(DEVICE(spi_gpio), "SPI_CS_in", 0));
     qdev_connect_gpio_out_named(DEVICE(&bmc->soc.gpio), "sysbus-irq", AST_GPIO_IRQ_X3_NUM,
                                 qdev_get_gpio_in_named(DEVICE(spi_gpio), "SPI_CLK", 0));
-    qdev_connect_gpio_out_named(DEVICE(&bmc->soc.gpio), "sysbus-irq", AST_GPIO_IRQ_X4_NUM,
-                                qdev_get_gpio_in_named(DEVICE(spi_gpio), "SPI_MOSI", 0));
     object_property_set_bool(OBJECT(spi_gpio->aspeed_gpio), "gpioX5", true, &error_fatal);
 
     memory_region_add_subregion(get_system_memory(),

--- a/include/hw/ssi/spi_gpio.h
+++ b/include/hw/ssi/spi_gpio.h
@@ -44,7 +44,7 @@ struct SpiGpioState {
     uint32_t output_byte;
     uint32_t input_byte;
 
-    bool clk, mosi, cs, miso;
+    bool clk, cs, miso;
     qemu_irq miso_output_pin, cs_output_pin;
 };
 


### PR DESCRIPTION
Bug identified:
`TPM returned invalid status` and tpm_tis_core crashed
See log: P517634973
When checking the cached MOSI pin values, they did not match the real time values polled from the gpio. This can be double checked during debugging

Bug context:
It turns out, mosi_set_level was not being called (due to an optimization between the kernel and aspeed_gpio). When this is not called, our MOSI pin value is incorrect and so the input pin value (being set by MOSI) is incorrect. 

Fix:
Now, we set the input pin directly from the gpio instead of waiting for it to be changed. 
This fix allows the tpm to be probed properly and finishes the qemu support for tpm (with a signed image)

Signed-off-by: Iris Chen <irischenlj@fb.com>